### PR TITLE
Features/qestions logic firestore

### DIFF
--- a/frontend/src/components/Navigataion/index.tsx
+++ b/frontend/src/components/Navigataion/index.tsx
@@ -1,8 +1,10 @@
-import styled from "styled-components";
-import Link from "next/link";
 import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import styled from "styled-components";
 
 const Navigation = () => {
+  const router = useRouter();
   const [showMenu, setShowMenu] = useState<boolean>(false);
   const level = 10; // 自分のレベルを仮に10とする
 
@@ -26,22 +28,24 @@ const Navigation = () => {
         </li>
         <li>
           <Link href="/" passHref>
-            <NavLink activeClassName="active">ホーム</NavLink>
+            <NavLink pathName={router.pathname} href="/">
+              ホーム
+            </NavLink>
           </Link>
         </li>
         <li>
           <Link href="/materials" passHref>
-            <NavLink activeClassName="active">教材一覧</NavLink>
+            <NavLink>教材一覧</NavLink>
           </Link>
         </li>
         <li>
           <Link href="/questions" passHref>
-            <NavLink activeClassName="active">質問</NavLink>
+            <NavLink>質問</NavLink>
           </Link>
         </li>
         <li>
           <Link href="/timeline" passHref>
-            <NavLink activeClassName="active">タイムライン</NavLink>
+            <NavLink>タイムライン</NavLink>
           </Link>
         </li>
         <LogoutButton>sign out</LogoutButton>
@@ -151,16 +155,17 @@ const BurgerMenu = styled.div<BurgerMenuProps>`
   }
 `;
 
-const NavLink = styled.a`
+interface NavLinkProps {
+  pathName?: string;
+  href?: string;
+}
+
+const NavLink = styled.a<NavLinkProps>`
   text-decoration: none;
-  color: white;
+  color: ${({ pathName, href }: NavLinkProps) => (href === pathName ? "#23aaff" : "#fff")};
   transition: all 0.3s ease-in-out;
 
   &:hover {
-    color: #23aaff;
-  }
-
-  &.active {
     color: #23aaff;
   }
 `;

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,38 +1,56 @@
-import React, { useContext, useState, useEffect, useRef } from 'react'
-import { auth, db } from '../../lib/FirebaseConfig'
-import { onAuthStateChanged } from 'firebase/auth'
+import React, { useContext, useState, useEffect } from 'react';
+import { auth } from '../../lib/FirebaseConfig';
+import { onAuthStateChanged } from 'firebase/auth';
+import { useSetRecoilState } from 'recoil';
+import { signInUserState } from '@/store/Auth/auth';
+
 
 // コンテキストを作成
-const AuthContext = React.createContext()
+const AuthContext = React.createContext();
 
 export function useAuth() {
     // useContextで作成したコンテキストを呼び出す
-    return useContext(AuthContext)
+    return useContext(AuthContext);
 }
 
 export function AuthProvider({ children }) {
-    const [currentUser, setCurrentUser] = useState(null)
-    const [loading, setLoading] = useState(true)
+    const [currentUser, setCurrentUser] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const setSignInUser = useSetRecoilState(signInUserState);
 
     // 第2引数に[]を指定して、初回レンダリングのみ関数を実行させる
     useEffect(() => {
         // onAuthStateChangedでログインの状態を監視する
-        const unsubscribe = onAuthStateChanged(auth, async user => {
+        const unsubscribe = onAuthStateChanged(auth, async (user) => {
             // ユーザー情報をcurrentUserに格納する
-            setCurrentUser(user)
-            setLoading(false)
-        })
-        return unsubscribe
-    }, [])
+            setCurrentUser(user);
+            setLoading(false);
+
+            // ログイン中のユーザー情報をsignInUserStateに保存する
+            if (user) {
+                setSignInUser({
+                    uid: user.uid,
+                    accessToken: user.accessToken,
+                });
+            } else {
+                // ログアウトしている場合はsignInUserStateを初期化する
+                setSignInUser({
+                    uid: null,
+                    accessToken: null,
+                });
+            }
+        });
+        return unsubscribe;
+    }, []);
 
     const value = {
-        currentUser
-    }
+        currentUser,
+    };
 
     // _app.jsで全コンポーネントをラッピングするためのプロバイダー
     return (
         <AuthContext.Provider value={value}>
             {!loading && children}
         </AuthContext.Provider>
-    )
+    );
 }


### PR DESCRIPTION
# タスク
- [ ] 質問一覧をfirebaseから取得する機能の実装
- [ ] 質問投稿に教材一覧から取得したデータを一緒に保存する機能を実装

### 備考
- userIdを取得しフィルタリングする必要があったため、recoilのstateにログイン情報を管理した
- データ取得の処理をuseEffectで./pages/questions/index.tsxに直接実装している。